### PR TITLE
Maintain release notes with GitHub Actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,25 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "⚠️ Breaking Changes"
+    label: "⚠️ Breaking"
+  - title: "✨ New Features"
+    label: "✨ Feature"
+  - title: "🐛 Bug Fixes"
+    label: "🐛 Bug Fix"
+  - title: "📚 Documentation"
+    label: "📚 Docs"
+  - title: "🏠 Housekeeping"
+    label: "🏠 Housekeeping"
+version-resolver:
+  minor:
+    labels:
+      - "⚠️ Breaking"
+      - "✨ Feature"
+  default: patch
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+no-changes-template: "- No changes"
+template: |
+  $CHANGES
+
+  **Full Changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,0 @@
-# 1.0.0
-
- - Switch serialization to canonical YAML documents to allow snapshotting stuff other than strings #6

--- a/minitest-snapshots.gemspec
+++ b/minitest-snapshots.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/minitest-snapshots/issues",
-    "changelog_uri" => "https://github.com/mattbrictson/minitest-snapshots/blob/main/Changelog.md",
+    "changelog_uri" => "https://github.com/mattbrictson/minitest-snapshots/releases",
     "source_code_uri" => "https://github.com/mattbrictson/minitest-snapshots",
     "homepage_uri" => spec.homepage,
     "rubygems_mfa_required" => "true"


### PR DESCRIPTION
This commit sets up a GitHub Actions workflow that uses Release Drafter to automatically maintain release notes on every push.

In practice this means that contributors no longer have to manually update `Changelog.md`, which is something that is easy to forget and often introduces tedious merge conflicts.

Instead, Release Drafter automatically adds the title of the PR to the GitHub release notes to a draft release, crediting the author of the PR, and linking to the PR number. Release Drafter furthermore organizes the release notes into sections according to the labels assigned to the PRs:

- ⚠️ Breaking
- 🐛 Bug Fix
- 📚 Docs
- ✨ Feature
- 🏠 Housekeeping