### PR TITLE
Add Gemfile.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/Gemfile.lock


### PR DESCRIPTION
We use a matrix in CI to test the project against various versions of Ruby. It is possible that different versions will have different dependency resolutions, hence different lockfiles.

Instead of pinning the project to a specific version of Ruby by committing that version's lockfile, I prefer to keep the lockfile out of git.