### PR TITLE
Add rubocop with not-too-strict config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
 jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.2"
+          bundler-cache: true
+      - run: bundle exec rubocop
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,199 @@
+require:
+  - rubocop-minitest
+  - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rake
+
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  NewCops: enable
+  TargetRubyVersion: 2.7
+  Exclude:
+    - "tmp/**/*"
+    - "vendor/**/*"
+
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+  AllowBeforeTrailingComments: true
+  ForceEqualSignAlignment: false
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: always_inspect
+
+Layout/LineLength:
+  Exclude:
+    - config/initializers/content_security_policy.rb
+
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Lint/DuplicateBranch:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Max: 25
+  Exclude:
+    - config/**/*
+    - test/**/*
+
+Metrics/ClassLength:
+  Max: 200
+  Exclude:
+    - test/**/*
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - db/migrate/*
+    - test/**/*
+
+Metrics/ModuleLength:
+  Max: 200
+  Exclude:
+    - config/**/*
+
+Metrics/ParameterLists:
+  Max: 6
+
+Metrics/PerceivedComplexity:
+  Max: 8
+
+Minitest/AssertPredicate:
+  Enabled: false
+
+Minitest/AssertTruthy:
+  Enabled: false
+
+Minitest/EmptyLineBeforeAssertionMethods:
+  Enabled: false
+
+Minitest/MultipleAssertions:
+  Enabled: false
+
+Minitest/RefuteFalse:
+  Enabled: false
+
+Minitest/RefutePredicate:
+  Enabled: false
+
+Naming/FileName:
+  Exclude:
+    - .tomo/plugins/*.rb
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Rake/Desc:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FetchEnvVar:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: false
+
+Style/StringConcatenation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/TrivialAccessors:
+  AllowPredicates: true
+
+Style/YodaExpression:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@ gemspec
 
 gem "minitest", "~> 5.14"
 gem "rake", "~> 13.0"
+gem "rubocop", "1.53.1"
+gem "rubocop-minitest", "0.31.0"
+gem "rubocop-packaging", "0.5.2"
+gem "rubocop-performance", "1.18.0"
+gem "rubocop-rake", "0.6.0"

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ task :verify_gemspec_files do
     If not, you may need to delete these files or modify the gemspec to ensure
     that they are not included in the gem by mistake:
 
-    #{ignored_by_git.join("\n").gsub(/^/, '  ')}
+    #{ignored_by_git.join("\n").gsub(/^/, "  ")}
 
   ERROR
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rubocop/rake_task"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -7,7 +8,9 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task default: :test
+RuboCop::RakeTask.new
+
+task default: %i[test rubocop]
 
 # == "rake release" enhancements ==============================================
 

--- a/lib/minitest/snapshots.rb
+++ b/lib/minitest/snapshots.rb
@@ -2,8 +2,7 @@ require "minitest"
 
 module Minitest::Snapshots
   class << self
-    attr_accessor :force_updates
-    attr_accessor :lock_snapshots
+    attr_accessor :force_updates, :lock_snapshots
 
     def default_snapshots_directory
       if defined?(Rails) && Rails.respond_to?(:root)

--- a/lib/minitest/snapshots/assertion_extensions.rb
+++ b/lib/minitest/snapshots/assertion_extensions.rb
@@ -8,10 +8,17 @@ module Minitest
       snapshot = Minitest::Snapshots::Serializer.serialize(value)
 
       if !Minitest::Snapshots.force_updates && File.exist?(snapshot_file)
-        assert_equal File.read(snapshot_file), snapshot, "The value does not match the snapshot (located at #{snapshot_file})"
+        assert_equal(
+          File.read(snapshot_file),
+          snapshot,
+          "The value does not match the snapshot (located at #{snapshot_file})"
+        )
       else
         if Minitest::Snapshots.lock_snapshots
-          assert false, "Attempt to create a snapshot failed because writing is prevented by the --lock-snapshots option"
+          assert(
+            false,
+            "Attempt to create a snapshot failed because writing is prevented by the --lock-snapshots option"
+          )
         end
 
         FileUtils.mkdir_p(File.dirname(snapshot_file))

--- a/lib/minitest/snapshots/serializer.rb
+++ b/lib/minitest/snapshots/serializer.rb
@@ -33,26 +33,24 @@ module Minitest
       # and are not installed if custom hooks are already defined.
       def self.serialize(value)
         @lock.synchronize do
-          begin
-            if (hook_hash = hook?(Hash))
-              Hash.define_method(HOOK) do |coder|
-                sorted = sort_by { |pair| pair.first.to_yaml }.to_h
-                coder.map = dup.clear.merge!(sorted)
-              end
+          if (hook_hash = hook?(Hash))
+            Hash.define_method(HOOK) do |coder|
+              sorted = sort_by { |pair| pair.first.to_yaml }.to_h
+              coder.map = dup.clear.merge!(sorted)
             end
-
-            if (hook_set = hook?(Set))
-              Set.define_method(HOOK) do |coder|
-                sorted = sort_by(&:to_yaml)
-                coder.seq = dup.clear.merge(sorted)
-              end
-            end
-
-            value.to_yaml
-          ensure
-            Hash.remove_method(HOOK) if hook_hash
-            Set.remove_method(HOOK) if hook_set
           end
+
+          if (hook_set = hook?(Set))
+            Set.define_method(HOOK) do |coder|
+              sorted = sort_by(&:to_yaml)
+              coder.seq = dup.clear.merge(sorted)
+            end
+          end
+
+          value.to_yaml
+        ensure
+          Hash.remove_method(HOOK) if hook_hash
+          Set.remove_method(HOOK) if hook_set
         end
       end
 

--- a/lib/minitest/snapshots/serializer.rb
+++ b/lib/minitest/snapshots/serializer.rb
@@ -1,5 +1,5 @@
-require 'set'
-require 'yaml'
+require "set"
+require "yaml"
 
 module Minitest
   module Snapshots

--- a/lib/minitest/snapshots/test_extensions.rb
+++ b/lib/minitest/snapshots/test_extensions.rb
@@ -22,7 +22,7 @@ module Minitest
       end
 
       def snapshot_path(suite_name, snapshot_name)
-        filename = "%s__%s.snap.yaml" % [sanitize(name), sanitize(snapshot_name)]
+        filename = format("%s__%s.snap.yaml", sanitize(name), sanitize(snapshot_name))
         subdir = sanitize(suite_name)
         File.join(@snapshot_dir, subdir, filename)
       end

--- a/lib/minitest/snapshots/test_extensions.rb
+++ b/lib/minitest/snapshots/test_extensions.rb
@@ -12,7 +12,7 @@ module Minitest
       private
 
       def sanitize(name)
-        sanitized = name.to_s.downcase.gsub(/(?:\A[\W_]+)|(?:[\W_]+\z)/, '').gsub(/[\W_]+/, '_')
+        sanitized = name.to_s.downcase.gsub(/(?:\A[\W_]+)|(?:[\W_]+\z)/, "").gsub(/[\W_]+/, "_")
 
         if sanitized.empty?
           raise NameError, "Can't sanitize name: #{name.inspect}"

--- a/lib/minitest/snapshots/version.rb
+++ b/lib/minitest/snapshots/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Snapshots
-    VERSION = "1.0.0"
+    VERSION = "1.0.0".freeze
   end
 end

--- a/lib/minitest/snapshots_plugin.rb
+++ b/lib/minitest/snapshots_plugin.rb
@@ -15,6 +15,6 @@ module Minitest
   def self.plugin_snapshots_init(_options)
     require_relative "snapshots/test_extensions"
     require_relative "snapshots/assertion_extensions"
-    Minitest::Test.send :include, Minitest::Snapshots::TestExtensions
+    Minitest::Test.include Minitest::Snapshots::TestExtensions
   end
 end

--- a/lib/minitest/snapshots_plugin.rb
+++ b/lib/minitest/snapshots_plugin.rb
@@ -2,7 +2,7 @@ require_relative "snapshots"
 require_relative "snapshots/version"
 
 module Minitest
-  def self.plugin_snapshots_options(opts, options)
+  def self.plugin_snapshots_options(opts, _options)
     opts.on "-u", "--update-snapshots", "Update (overwrite) stored snapshots" do
       Minitest::Snapshots.force_updates = true
     end
@@ -12,7 +12,7 @@ module Minitest
     end
   end
 
-  def self.plugin_snapshots_init(options)
+  def self.plugin_snapshots_init(_options)
     require_relative "snapshots/test_extensions"
     require_relative "snapshots/assertion_extensions"
     Minitest::Test.send :include, Minitest::Snapshots::TestExtensions

--- a/test/minitest_snapshots_test.rb
+++ b/test/minitest_snapshots_test.rb
@@ -14,7 +14,7 @@ class TestSnapshots < Minitest::Test
   end
 
   def test_hash_matches
-    assert_matches_snapshot({ foo: "bar", baz: 1, qux: { foo: "corge" } })
+    assert_matches_snapshot({foo: "bar", baz: 1, qux: {foo: "corge"}})
   end
 
   def test_set


### PR DESCRIPTION
- Install rubocop gems with not-to-strict config that is similar to [standard](https://github.com/standardrb/standard)
- Run rubocop as part of the default rake task
- Add a rubocop job to GitHub Actions
- Fix several minor code style violations (see individual commits)

The only code changes in this PR, aside from formatting, are:

- [Remove redundant begin/end block](https://github.com/mattbrictson/minitest-snapshots/pull/19/commits/b407ff18be2fcf5a28fffc14012ec8e31fa10f2f)
- [Use `format` instead of `%`](https://github.com/mattbrictson/minitest-snapshots/pull/19/commits/e379e0842c6bd51d2648096591c4d330b48ba420)