### PR TITLE
Add project history to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ The gem is available as open source under the terms of the [MIT License](LICENSE
 ## Code of Conduct
 
 Everyone interacting in the this project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).
+
+## History
+
+`minitest-snapshots` was created by Harry Brundage (@airhorns) and originally published to rubygems in 2019. Significant contributions were [added](https://github.com/mattbrictson/minitest-snapshots/pull/6) by @chocolateboy in 2020. In June 2023, ownership of the project was transferred to Matt Brictson (@mattbrictson).


### PR DESCRIPTION
@airhorns I wanted to make sure you are properly credited in the README even though the project has moved under my GitHub account. If you'd rather phrase things differently or add more background to it, let me know. I only discovered this project recently, so I don't know the whole history.