### PR TITLE
Add downloads badge to README and switch to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Minitest::Snapshots
 
-[![Gem Version](https://badge.fury.io/rb/minitest-snapshots.svg)](https://rubygems.org/gems/minitest-snapshots)
-[![CI](https://github.com/mattbrictson/gem/actions/workflows/ci.yml/badge.svg)](https://github.com/mattbrictson/gem/actions/workflows/ci.yml)
+[![Gem Version](https://img.shields.io/gem/v/minitest-snapshots)](https://rubygems.org/gems/minitest-snapshots)
+[![Gem Downloads](https://img.shields.io/gem/dt/minitest-snapshots)](https://www.ruby-toolbox.com/projects/minitest-snapshots)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/mattbrictson/minitest-snapshots/ci.yml)](https://github.com/mattbrictson/gem/actions/workflows/ci.yml)
 
 Simple minitest plugin gem implementing Jest-style snapshot testing. It's like VCR, but for any value.
 


### PR DESCRIPTION
Rubygems download count is a more interesting indication of how this gem is used, above and beyond the star/fork metrics that GitHub is able to provide. This PR adds a badge to the README with the download count.

Also, I've standardized on `shields.io` as the source for all badges, for consistency (previously there was a mix of `badge.fury.io` and `github.com`, with slightly different colors).