### PR TITLE
Enable `--lock-snapshots` by default in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 ## Command line options
 
 - `-u` or `--update-snapshots`: Update snapshots on disk to the new actual value when re-running the test. Useful when you know the new output of a test case is correct and the snapshot is out of date.
-- `-l` or `--lock-snapshots`: Prevents new snapshots from being written. Useful on CI to ensure all snapshots have been written by the developer.
+- `-l` or `--lock-snapshots`: Prevents new snapshots from being written. This is enabled by default in CI (i.e. when the `CI` env var is present).
 
 For example, to update snapshots on a Rails project:
 

--- a/lib/minitest/snapshots_plugin.rb
+++ b/lib/minitest/snapshots_plugin.rb
@@ -3,12 +3,14 @@ require_relative "snapshots/version"
 
 module Minitest
   def self.plugin_snapshots_options(opts, _options)
+    Minitest::Snapshots.lock_snapshots = !ENV["CI"].to_s.empty?
+
     opts.on "-u", "--update-snapshots", "Update (overwrite) stored snapshots" do
       Minitest::Snapshots.force_updates = true
     end
 
-    opts.on "-l", "--lock-snapshots", "Prevent any snapshots from being stored" do
-      Minitest::Snapshots.lock_snapshots = true
+    opts.on "-l", "--[no-]lock-snapshots", "Prevent any snapshots from being stored" do |bool|
+      Minitest::Snapshots.lock_snapshots = bool
     end
   end
 

--- a/test/minitest/snapshots_plugin_test.rb
+++ b/test/minitest/snapshots_plugin_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Minitest::SnapshotsPluginTest < Minitest::Test
+  def setup
+    @orig_ci_value = ENV["CI"]
+    @opt_parse = OptionParser.new
+  end
+
+  def teardown
+    ENV["CI"] = @orig_ci_value
+  end
+
+  def test_does_not_lock_snapshots_by_default
+    ENV["CI"] = nil
+    register_plugin
+
+    refute Minitest::Snapshots.lock_snapshots
+  end
+
+  def test_locks_snapshots_by_defaut_in_ci
+    ENV["CI"] = "1"
+    register_plugin
+
+    assert Minitest::Snapshots.lock_snapshots
+  end
+
+  def test_lock_snapshots_can_be_disabled_in_ci_via_command_line_flag
+    ENV["CI"] = "1"
+    register_plugin
+    @opt_parse.parse!(["--no-lock-snapshots"])
+
+    refute Minitest::Snapshots.lock_snapshots
+  end
+
+  private
+
+  def register_plugin
+    Minitest.plugin_snapshots_options(@opt_parse, {})
+  end
+end


### PR DESCRIPTION
## Problem

When running tests in CI, we never want new snapshots to be recorded. If a snapshot is missing in CI, that means that either (1) a snapshot was never recorded, meaning the test is being run for the first time; or (2) the snapshot was recorded, but the developer forgot to check the snapshot file into source control.

In both cases, we want CI to fail, rather than silently recording a new snapshot and passing the test.

## Solution

With this PR, minitest-snapshots now checks to see if it is running in CI by the presence of the `CI` environment variable. If present, `--lock-snapshots` is enabled by default.

This can be overridden by explicitly passing `--no-lock-snapshots`.